### PR TITLE
API changes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
   },
   "rules": {
     "prefer-destructuring": 0,
+    "import/prefer-default-export": 0,
     "prettier/prettier": [
       "error",
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-- Breaking change - API now all processes text lines, so it is recommended to simply supply parseLine with the text line and options opts arguments containing things like uniqueId 
+### Major changes
+
+- API now processes just text lines with the parseLine method
 - Remove snake case of results
-- Make returned values match very faithfully the autoSql and default schema including using the chrom, chromStart, and chromEnd fields instead of renaming them to refName, start and end
+- Returned values match autoSql very faithfully and uses the naming from UCSC e.g. {chrom, chromStart, chromEnd} unless opts.regularize is passed to parseLine and then it returns the names {refName,start,end}
 
 
 ## [1.0.4](https://github.com/GMOD/bed-js/compare/v1.0.3...v1.0.4) (2019-04-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 - API now processes just text lines with the parseLine method
 - Remove snake case of results
-- Returned values match autoSql very faithfully and uses the naming from UCSC e.g. {chrom, chromStart, chromEnd} unless opts.regularize is passed to parseLine and then it returns the names {refName,start,end}
+- Returned values match autoSql very faithfully and uses the naming from UCSC e.g. exact strings from autoSql {chrom, chromStart, chromEnd}
 - Accepts a opts.uniqueId for the parseLine method which adds this to the featureData
 - Parses the default BED schema with a defaultBedSchema.as autoSql definition instead of a separate method
-- Doesn't return strand on features if the autoSql does not include it
 
 
 ## [1.0.4](https://github.com/GMOD/bed-js/compare/v1.0.3...v1.0.4) (2019-04-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - API now processes just text lines with the parseLine method
 - Remove snake case of results
 - Returned values match autoSql very faithfully and uses the naming from UCSC e.g. {chrom, chromStart, chromEnd} unless opts.regularize is passed to parseLine and then it returns the names {refName,start,end}
+- Accepts a opts.uniqueId for the parseLine method which adds this to the featureData
+- Parses the default BED schema with a defaultBedSchema.as autoSql definition instead of a separate method
+- Doesn't return strand on features if the autoSql does not include it
 
 
 ## [1.0.4](https://github.com/GMOD/bed-js/compare/v1.0.3...v1.0.4) (2019-04-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
+- Breaking change - API now all processes text lines, so it is recommended to simply supply parseLine with the text line and options opts arguments containing things like uniqueId 
 - Remove snake case of results
-- Changed API so that it is recommended to pass everything through to parseLine with the line argument being plain tab separated text line and opts containing optional values
+- Make returned values match very faithfully the autoSql and default schema including using the chrom, chromStart, and chromEnd fields instead of renaming them to refName, start and end
 
 
 ## [1.0.4](https://github.com/GMOD/bed-js/compare/v1.0.3...v1.0.4) (2019-04-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- Remove snake case of results
+- Changed API so that it is recommended to pass everything through to parseLine with the line argument being plain tab separated text line and opts containing optional values
+
+
 ## [1.0.4](https://github.com/GMOD/bed-js/compare/v1.0.3...v1.0.4) (2019-04-14)
 
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,8 @@ p.parseLine(line)
 ### Important notes
 
 
-* Does not convert blockSizes/blockStarts to gene features
 * Does not parse "browser" or "track" lines and will throw an error if parseLine receives one of these
-* Does not handle files that use spaces instead of tabs even though this is allowed by UCSC
+* By default, parseLine parses only tab delimited text, if you want to use spaces as is allowed by UCSC then pass an array to `line` for parseLine
 
 
 ## Academic Use

--- a/README.md
+++ b/README.md
@@ -40,21 +40,7 @@ The predefined types can include
     mafFrames
     mafSummary
 
-If neither autoSql or type is specified, the default BED schema is used
-
-    chrom
-    chromStart
-    chromEnd
-    name
-    score
-    strand
-    thickStart
-    thickEnd
-    itemRgb
-    blockCount
-    blockSizes
-    blockStarts
-
+If neither autoSql or type is specified, the default BED schema is used (see [here](src/as/defaultBedSchema.as))
 
 ### parseLine(line, opts)
 
@@ -140,8 +126,8 @@ p.parseLine(line)
 ### Important notes
 
 
-* Does not convert blockStarts/blockEnds to gene features
-* Does not parse "header" or "track" lines and will throw an error if parseLine receives one of these
+* Does not convert blockSizes/blockStarts to gene features
+* Does not parse "browser" or "track" lines and will throw an error if parseLine receives one of these
 * Does not handle files that use spaces instead of tabs even though this is allowed by UCSC
 
 

--- a/README.md
+++ b/README.md
@@ -46,16 +46,15 @@ If neither autoSql or type is specified, the default BED schema is used (see [he
 
 Parses a BED line according to the currently loaded schema
 
-* line - is a tab delimited line with fields from the schema
-* opts - an options object
+* line: string|Array<string> - is a tab delimited line with fields from the schema, or an array of fields with fields from the schema
+* opts: Options - an options object
 
-An options object can contain
+An Options object can contain
 
 * opts.uniqueId - an indication of a uniqueId that is not encoded by the BED line itself
-* opts.regularize - an indication to change the fields {chrom, chromStart, chromEnd} to {refName, start, end}
 
 The default instantiation of the parser with new BED() simply parses lines assuming the fields come from the standard BED schema.
-Your line can just contain the subset of the fields `chrom, chromStart, chromEnd, name, score`
+Your line can just contain just a subset of the fields e.g. `chrom, chromStart, chromEnd, name, score`
 
 
 ## Examples
@@ -66,40 +65,35 @@ Your line can just contain the subset of the fields `chrom, chromStart, chromEnd
 const p = new BED()
 
 p.parseLine('chr1\t0\t100')
-// outputs { chrom: 'chr1', chromStart: 0, chromEnd: 100 }
-
-p.parseLine('chr1\t0\t100', {regularize: true, uniqueId: 1})
-// outputs { uniqueId: 1, refName: 'chr1', start: 0, end: 100 }
+// outputs { chrom: 'chr1', chromStart: 0, chromEnd: 100, strand: 0 }
 ```
-
-Note that regularizing changes the names of some fields in the output, a convenience method
 
 
 ### Parsing BED with a built in schema e.g. bigGenePred
 
-If you have a BED format that corresponds to a different schema, you can specify from a list of default built in alternate schemas or specify an autoSql as a string
+If you have a BED format that corresponds to a different schema, you can specify from the list of default built in schemas
 
-Specify this in the type for the BED constructor
+Specify this in the opts.type for the BED constructor
 
 ```js
 const p = new BED({ type: 'bigGenePred' })
 const line = 'chr1\t11868\t14409\tENST00000456328.2\t1000\t+\t11868\t11868\t255,128,0\t3\t359,109,1189,\t0,744,1352,\tDDX11L1\tnone\tnone\t-1,-1,-1,\tnone\tENST00000456328.2\tDDX11L1\tnone'
 p.parseLine(line)
 // above line outputs
-      { chrom: 'chr1',                                                                                                                                                      
-        chromStart: 11868,                                                                                                                                                  
-        chromEnd: 14409,                                                                                                                                                    
-        name: 'ENST00000456328.2',                                                                                                                                          
-        score: 1000,                                                                                                                                                        
-        strand: 1,                                                                                                                                                          
-        thickStart: 11868,                                                                                                                                                  
-        thickEnd: 11868,                                                                                                                                                    
-        reserved: '255,128,0',                                                                                                                                              
-        blockCount: 3,                                                                                                                                                      
-        blockSizes: [ 359, 109, 1189 ],                                                                                                                                     
-        chromStarts: [ 0, 744, 1352 ],                                                                                                                                      
-        name2: 'DDX11L1',                                                                                                                                                   
-        cdsStartStat: 'none',                                                                                                                                               
+      { chrom: 'chr1',
+        chromStart: 11868,
+        chromEnd: 14409,
+        name: 'ENST00000456328.2',
+        score: 1000,
+        strand: 1,
+        thickStart: 11868,
+        thickEnd: 11868,
+        reserved: '255,128,0',
+        blockCount: 3,
+        blockSizes: [ 359, 109, 1189 ],
+        chromStarts: [ 0, 744, 1352 ],
+        name2: 'DDX11L1',
+        cdsStartStat: 'none',
         cdsEndStat: 'none',
         exonFrames: [ -1, -1, -1 ],
         type: 'none',
@@ -128,6 +122,7 @@ p.parseLine(line)
 
 * Does not parse "browser" or "track" lines and will throw an error if parseLine receives one of these
 * By default, parseLine parses only tab delimited text, if you want to use spaces as is allowed by UCSC then pass an array to `line` for parseLine
+* Converts strand from {+,-,.} to {1,-1,0} and also sets strand 0 even if no strand is in the autoSql
 
 
 ## Academic Use

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The default instantiation of the parser with new BED() simply parses lines assum
 ```js
 const p = new BED()
 const feature = p.parseLine('chr1\t0\t100')
+// { chrom: 'chr1', chromStart: 0, chromEnd: 100, strand: 0 }
 ```
 
 The default schema is the same 12 fields as UCSC
@@ -68,27 +69,26 @@ const p = new BED({ type: 'bigGenePred' })
 const line = 'chr1\t11868\t14409\tENST00000456328.2\t1000\t+\t11868\t11868\t255,128,0\t3\t359,109,1189,\t0,744,1352,\tDDX11L1\tnone\tnone\t-1,-1,-1,\tnone\tENST00000456328.2\tDDX11L1\tnone'
 p.parseLine(line)
 // above line outputs
-      { refID: 'chr1',
-        start: 11868,
-        end: 14409,
+      { chrom: 'chr1',
+        chromStart: 11868,
+        chromEnd: 14409,
         name: 'ENST00000456328.2',
         score: 1000,
         strand: 1,
-        thick_start: 11868,
-        thick_end: 11868,
+        thickStart: 11868,
+        thickEnd: 11868,
         reserved: '255,128,0',
-        block_count: 3,
-        block_sizes: [ 359, 109, 1189 ],
-        chrom_starts: [ 0, 744, 1352 ],
+        blockCount: 3,
+        blockSizes: [ 359, 109, 1189 ],
+        chromStarts: [ 0, 744, 1352 ],
         name2: 'DDX11L1',
-        cds_start_stat: 'none',
-        cds_end_stat: 'none',
-        exon_frames: [ -1, -1, -1 ],
+        cdsStartStat: 'none',
+        cdsEndStat: 'none',
+        exonFrames: [ -1, -1, -1 ],
         type: 'none',
-        gene_name: 'ENST00000456328.2',
-        gene_name2: 'DDX11L1',
-        gene_type: 'none' }
-
+        geneName: 'ENST00000456328.2',
+        geneName2: 'DDX11L1',
+        geneType: 'none' }
 ```
 
 ### BED parser with autoSql

--- a/src/as/defaultBedSchema.as
+++ b/src/as/defaultBedSchema.as
@@ -1,0 +1,16 @@
+table defaultBedSchema
+"BED12"
+    (
+    string chrom;      "The name of the chromosome (e.g. chr3, chrY, chr2_random) or scaffold (e.g. scaffold10671)."
+    uint   chromStart; "The starting position of the feature in the chromosome or scaffold. The first base in a chromosome is numbered 0."
+    uint   chromEnd;   "The ending position of the feature in the chromosome or scaffold. The chromEnd base is not included in the display of the feature. For example, the first 100 bases of a chromosome are defined as chromStart=0, chromEnd=100, and span the bases numbered 0-99."
+    string   name;   "Defines the name of the BED line."
+    float   score;   "Feature score, doesn't care about the 0-1000 limit as in bed"
+    char   strand;   "Defines the strand. Either '.' (=no strand) or '+' or '-'"
+    uint thickStart; "The starting position at which the feature is drawn thickly (for example, the start codon in gene displays). When there is no thick part, thickStart and thickEnd are usually set to the chromStart position."
+    uint thickEnd; "The ending position at which the feature is drawn thickly (for example the stop codon in gene displays)."
+    string itemRgb; "An RGB value of the form R,G,B (e.g. 255,0,0). "
+    uint blockCount; " The number of blocks (exons) in the BED line."
+    uint[blockCount] blockSizes; " A comma-separated list of the block sizes. The number of items in this list should correspond to blockCount."
+    uint[blockCount] blockStart; "A comma-separated list of block starts. All of the blockStart positions should be calculated relative to chromStart. The number of items in this list should correspond to blockCount."
+    )

--- a/src/as/defaultBedSchema.as
+++ b/src/as/defaultBedSchema.as
@@ -12,5 +12,5 @@ table defaultBedSchema
     string itemRgb; "An RGB value of the form R,G,B (e.g. 255,0,0). "
     uint blockCount; " The number of blocks (exons) in the BED line."
     uint[blockCount] blockSizes; " A comma-separated list of the block sizes. The number of items in this list should correspond to blockCount."
-    uint[blockCount] blockStart; "A comma-separated list of block starts. All of the blockStart positions should be calculated relative to chromStart. The number of items in this list should correspond to blockCount."
+    uint[blockCount] blockStarts; "A comma-separated list of block starts. All of the blockStart positions should be calculated relative to chromStart. The number of items in this list should correspond to blockCount."
     )

--- a/src/defaultTypes.js
+++ b/src/defaultTypes.js
@@ -8,6 +8,7 @@ import bigLink from './as/bigLink.as'
 import bigChain from './as/bigChain.as'
 import mafFrames from './as/mafFrames.as'
 import mafSummary from './as/mafSummary.as'
+import defaultBedSchema from './as/defaultBedSchema.as'
 
 const types = {
   bigInteract,
@@ -19,6 +20,7 @@ const types = {
   bigChain,
   mafFrames,
   mafSummary,
+  defaultBedSchema,
 }
 
 Object.keys(types).forEach(k => {

--- a/src/parse.js
+++ b/src/parse.js
@@ -18,24 +18,22 @@ export default class BED {
   /*
    * parses a line of text as a BED line with the loaded autoSql schema
    *
-   * @param line - a BED line
-   * @param opts - supply opts.uniqueId have a uniqueId not encoded in BED file itself
+   * @param line - a BED line as tab delimited text or array
+   * @param opts - supply opts.uniqueId and opts.regularize
    * @return a object representing a feature
    */
   parseLine(line, opts = {}) {
     const { autoSql } = this
-    if (line.startsWith('track') || line.startsWith('browser'))
-      throw new Error(
-        `Error: track and browser line parsing is not supported, please filter:\n${line}`,
-      )
+    const { regularize, uniqueId } = opts
+    let fields = line
+    if (!Array.isArray(line)) {
+      if (line.startsWith('track') || line.startsWith('browser'))
+        throw new Error(
+          `Error: track and browser line parsing is not supported, please filter:\n${line}`,
+        )
+      fields = line.split('\t')
+    }
 
-    if (!autoSql)
-      throw new Error(
-        'no autoSql configured, please supply autoSql or format to BED constructor',
-      )
-
-    const { uniqueId } = opts // optionally supply a uniqueId based on fileoffset
-    const fields = line.split('\t')
     const featureData = {}
     if (uniqueId) featureData.uniqueId = uniqueId
 
@@ -72,7 +70,7 @@ export default class BED {
       featureData.strand = { '-': -1, '+': 1 }[featureData.strand] || 0
     }
 
-    if (opts.regularize) {
+    if (regularize) {
       return regularizeFeat(featureData)
     }
     return featureData

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,6 +1,6 @@
 import parser from './autoSql'
 import types from './defaultTypes'
-import { detectTypes } from './util'
+import { regularizeFeat, detectTypes } from './util'
 
 export default class BED {
   constructor(args = {}) {
@@ -13,12 +13,6 @@ export default class BED {
     } else {
       this.autoSql = detectTypes(types.defaultBedSchema)
     }
-  }
-
-  static unescape(s = '') {
-    return s.replace(/%([0-9A-Fa-f]{2})/g, (match, seq) =>
-      String.fromCharCode(parseInt(seq, 16)),
-    )
   }
 
   /*
@@ -52,8 +46,6 @@ export default class BED {
       if (columnVal === null || columnVal === undefined) {
         break
       }
-      console.log(autoField)
-
       if (columnVal !== '.') {
         if (isNumeric) {
           const num = Number(columnVal)
@@ -73,7 +65,7 @@ export default class BED {
     }
 
     if (featureData.chrom) {
-      featureData.chrom = BED.unescape(featureData.chrom)
+      featureData.chrom = decodeURIComponent(featureData.chrom)
     }
 
     if (featureData.strand) {
@@ -81,18 +73,8 @@ export default class BED {
     }
 
     if (opts.regularize) {
-      return this.regularizeFeat(featureData)
+      return regularizeFeat(featureData)
     }
     return featureData
-  }
-
-  regularizeFeat(featureData) {
-    const {
-      chrom: refName,
-      chromStart: start,
-      chromEnd: end,
-      ...rest
-    } = featureData
-    return { ...rest, refName, start, end }
   }
 }

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,12 +1,12 @@
 import parser from './autoSql'
 import types from './defaultTypes'
-import { regularizeFeat, detectTypes } from './util'
+import { detectTypes } from './util'
 
 export default class BED {
   constructor(args = {}) {
     if (args.autoSql) {
       this.autoSql = detectTypes(parser.parse(args.autoSql))
-    } else if (args.type && types[args.type]) {
+    } else if (args.type) {
       this.autoSql = detectTypes(
         types[args.type] || throw new Error('Type not found'),
       )
@@ -19,17 +19,17 @@ export default class BED {
    * parses a line of text as a BED line with the loaded autoSql schema
    *
    * @param line - a BED line as tab delimited text or array
-   * @param opts - supply opts.uniqueId and opts.regularize
+   * @param opts - supply opts.uniqueId
    * @return a object representing a feature
    */
   parseLine(line, opts = {}) {
     const { autoSql } = this
-    const { regularize, uniqueId } = opts
+    const { uniqueId } = opts
     let fields = line
     if (!Array.isArray(line)) {
       if (line.startsWith('track') || line.startsWith('browser'))
         throw new Error(
-          `Error: track and browser line parsing is not supported, please filter:\n${line}`,
+          `track and browser line parsing is not supported, please filter:\n${line}`,
         )
       fields = line.split('\t')
     }
@@ -65,14 +65,8 @@ export default class BED {
     if (featureData.chrom) {
       featureData.chrom = decodeURIComponent(featureData.chrom)
     }
+    featureData.strand = { '.': 0, '-': -1, '+': 1 }[featureData.strand] || 0
 
-    if (featureData.strand) {
-      featureData.strand = { '-': -1, '+': 1 }[featureData.strand] || 0
-    }
-
-    if (regularize) {
-      return regularizeFeat(featureData)
-    }
     return featureData
   }
 }

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,27 +1,6 @@
 import parser from './autoSql'
 import types from './defaultTypes'
-
-// adds annotation to autoSql fields
-// for numeric fields "isNumeric" is added
-// for array types "isArray" is added
-// for numeric array types "isArray" and "arrayIsNumeric" is set
-const detectTypes = autoSql => {
-  const numericTypes = ['uint', 'int', 'float', 'long']
-  const fields = autoSql.fields.map(autoField => {
-    const type = {}
-    if (!autoField.size && numericTypes.includes(autoField.type)) {
-      type.isNumeric = true
-    }
-    if (autoField.size) {
-      type.isArray = true
-    }
-    if (autoField.size && numericTypes.includes(autoField.type)) {
-      type.arrayIsNumeric = true
-    }
-    return { ...autoField, ...type }
-  })
-  return { ...autoSql, fields }
-}
+import { detectTypes } from './util'
 
 export default class BED {
   constructor(args = {}) {
@@ -31,61 +10,15 @@ export default class BED {
       this.autoSql = detectTypes(
         types[args.type] || throw new Error('Type not found'),
       )
+    } else {
+      this.autoSql = detectTypes(types.defaultBedSchema)
     }
-  }
-
-  parseLine(line, opts = {}) {
-    const { autoSql } = this
-    if (line.startsWith('track') || line.startsWith('browser'))
-      throw new Error(
-        `Error: track and browser line parsing is not supported, please filter:\n${line}`,
-      )
-    return autoSql
-      ? this.parseLineAutoSql(line, opts)
-      : BED.parseLineDefault(line, opts)
   }
 
   static unescape(s = '') {
     return s.replace(/%([0-9A-Fa-f]{2})/g, (match, seq) =>
       String.fromCharCode(parseInt(seq, 16)),
     )
-  }
-
-  // default BED12 fields, parses as many as possible of these in parseLineDefault
-  static featureNames = 'chrom chromStart chromEnd name score strand thickStart thickEnd itemRgb blockCount blockSizes blockStarts'.split(
-    ' ',
-  )
-
-  /*
-   * parses a line of text as a BED line with the default schema, can contain a subset of the BED12 fields
-   *
-   * @param line - a BED line
-   * @param opts - supply opts.uniqueId have a uniqueId not encoded in BED file itself
-   * @return a object representing a feature
-   */
-  static parseLineDefault(line, opts = {}) {
-    const fields = line.split('\t')
-    const f = fields.map(a => (a === '.' ? null : a))
-
-    const featureData = {}
-    for (let i = 0; i < BED.featureNames.length; i += 1) {
-      if (f[i] !== null && f[i] !== undefined) {
-        featureData[BED.featureNames[i]] = f[i]
-      }
-    }
-    if (featureData.chromStart !== null)
-      featureData.chromStart = parseInt(featureData.chromStart, 10)
-    if (featureData.chromEnd !== null)
-      featureData.chromEnd = parseInt(featureData.chromEnd, 10)
-    if (featureData.score != null)
-      featureData.score = parseFloat(featureData.score, 10)
-
-    // unescape only the ref columns
-    featureData.chrom = BED.unescape(featureData.chrom)
-    featureData.strand = { '+': 1, '-': -1 }[featureData.strand] || 0
-    if (opts.uniqueId) featureData.uniqueId = opts.uniqueId
-
-    return featureData
   }
 
   /*
@@ -95,13 +28,19 @@ export default class BED {
    * @param opts - supply opts.uniqueId have a uniqueId not encoded in BED file itself
    * @return a object representing a feature
    */
-  parseLineAutoSql(line, opts = {}) {
+  parseLine(line, opts = {}) {
     const { autoSql } = this
-    const { uniqueId } = opts // optionally supply a uniqueId based on fileoffset
+    if (line.startsWith('track') || line.startsWith('browser'))
+      throw new Error(
+        `Error: track and browser line parsing is not supported, please filter:\n${line}`,
+      )
+
     if (!autoSql)
       throw new Error(
         'no autoSql configured, please supply autoSql or format to BED constructor',
       )
+
+    const { uniqueId } = opts // optionally supply a uniqueId based on fileoffset
     const fields = line.split('\t')
     const featureData = {}
     if (uniqueId) featureData.uniqueId = uniqueId
@@ -111,9 +50,9 @@ export default class BED {
       let columnVal = fields[i]
       const { isNumeric, isArray, arrayIsNumeric, name } = autoField
       if (columnVal === null || columnVal === undefined) {
-        console.warn(`column ${i} does not exist, expected ${name}`)
         break
       }
+      console.log(autoField)
 
       if (columnVal !== '.') {
         if (isNumeric) {
@@ -133,7 +72,27 @@ export default class BED {
       }
     }
 
-    featureData.strand = { '-': -1, '+': 1 }[featureData.strand] || 0
+    if (featureData.chrom) {
+      featureData.chrom = BED.unescape(featureData.chrom)
+    }
+
+    if (featureData.strand) {
+      featureData.strand = { '-': -1, '+': 1 }[featureData.strand] || 0
+    }
+
+    if (opts.regularize) {
+      return this.regularizeFeat(featureData)
+    }
     return featureData
+  }
+
+  regularizeFeat(featureData) {
+    const {
+      chrom: refName,
+      chromStart: start,
+      chromEnd: end,
+      ...rest
+    } = featureData
+    return { ...rest, refName, start, end }
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -24,18 +24,3 @@ export function detectTypes(autoSql) {
   })
   return { ...autoSql, fields }
 }
-
-/*
- * regularizes a feature by modifying the {chrom,chromStart,chromEnd} to {refName,start,end}
- * @params featureData a feature to regularize
- * @return a regularized feature
- */
-export function regularizeFeat(featureData) {
-  const {
-    chrom: refName,
-    chromStart: start,
-    chromEnd: end,
-    ...rest
-  } = featureData
-  return { ...rest, refName, start, end }
-}

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,26 @@
+/*
+ * adds some type annotations to the autoSql schema
+ * for numeric fields ['uint', 'int', 'float', 'long'] "isNumeric" is added
+ * for array types "isArray" is added
+ * for numeric array types "isArray" and "arrayIsNumeric" is set
+ *
+ * @param autoSql - an autoSql schema from the peg parser
+ * @return autoSql with type annotations added
+ */
+export function detectTypes(autoSql) {
+  const numericTypes = ['uint', 'int', 'float', 'long']
+  const fields = autoSql.fields.map(autoField => {
+    const type = {}
+    if (!autoField.size && numericTypes.includes(autoField.type)) {
+      type.isNumeric = true
+    }
+    if (autoField.size && autoField.type !== 'char') {
+      type.isArray = true
+    }
+    if (autoField.size && numericTypes.includes(autoField.type)) {
+      type.arrayIsNumeric = true
+    }
+    return { ...autoField, ...type }
+  })
+  return { ...autoSql, fields }
+}

--- a/src/util.js
+++ b/src/util.js
@@ -24,3 +24,18 @@ export function detectTypes(autoSql) {
   })
   return { ...autoSql, fields }
 }
+
+/*
+ * regularizes a feature by modifying the {chrom,chromStart,chromEnd} to {refName,start,end}
+ * @params featureData a feature to regularize
+ * @return a regularized feature
+ */
+export function regularizeFeat(featureData) {
+  const {
+    chrom: refName,
+    chromStart: start,
+    chromEnd: end,
+    ...rest
+  } = featureData
+  return { ...rest, refName, start, end }
+}

--- a/test/__snapshots__/parse.test.js.snap
+++ b/test/__snapshots__/parse.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "chrom": "contigA",
   "chromEnd": 10884,
   "chromStart": 10875,
+  "strand": 0,
 }
 `;
 
@@ -13,6 +14,7 @@ Object {
   "chrom": "co,tigA",
   "chromEnd": 10884,
   "chromStart": 10875,
+  "strand": 0,
 }
 `;
 
@@ -44,6 +46,7 @@ Object {
   "chromEnd": 10884,
   "chromStart": 10875,
   "name": "test2",
+  "strand": 0,
 }
 `;
 
@@ -218,6 +221,7 @@ Object {
   "sourceChrom": "chr17",
   "sourceEnd": 58880897,
   "sourceStart": 58878552,
+  "strand": 0,
   "targetChrom": "chr3",
   "targetEnd": 63705638,
   "targetStart": 63702628,
@@ -232,6 +236,7 @@ Object {
   "chromStart": 7917,
   "name": "2912",
   "qStart": 75185566,
+  "strand": 0,
 }
 `;
 
@@ -241,10 +246,11 @@ Object {
   "chromEnd": 2,
   "chromStart": 0,
   "mafBlock": "a score=60.000000;s hg38.chr22_KI270731v1_random        0 2 +   150754 AC;s canFam3.chr26                27974205 2 + 38964690 AT;",
+  "strand": 0,
 }
 `;
 
-exports[`bigNarrowPeak bigNarrowPeak 1`] = `
+exports[`bigNarrowPeak 1`] = `
 Object {
   "chrom": "chr1",
   "chromEnd": 566953,
@@ -254,19 +260,22 @@ Object {
   "qValue": 4.80079,
   "score": 468,
   "signalValue": 103.84,
+  "strand": 0,
 }
 `;
 
-exports[`bigNarrowPeak with regularize bigNarrowPeak 1`] = `
+exports[`bigNarrowPeak 2`] = `
 Object {
-  "end": 566953,
+  "chrom": "chr1",
+  "chromEnd": 566953,
+  "chromStart": 566753,
   "pValue": 5.54347,
   "peak": 154,
   "qValue": 4.80079,
-  "refName": "chr1",
   "score": 468,
   "signalValue": 103.84,
-  "start": 566753,
+  "strand": 0,
+  "uniqueId": 1,
 }
 `;
 
@@ -379,6 +388,7 @@ Object {
   "rightStatus": "",
   "score": 0.568679,
   "src": "canFam3",
+  "strand": 0,
 }
 `;
 

--- a/test/__snapshots__/parse.test.js.snap
+++ b/test/__snapshots__/parse.test.js.snap
@@ -5,7 +5,6 @@ Object {
   "chrom": "contigA",
   "chromEnd": 10884,
   "chromStart": 10875,
-  "strand": 0,
 }
 `;
 
@@ -14,7 +13,6 @@ Object {
   "chrom": "co,tigA",
   "chromEnd": 10884,
   "chromStart": 10875,
-  "strand": 0,
 }
 `;
 
@@ -46,15 +44,20 @@ Object {
   "chromEnd": 10884,
   "chromStart": 10875,
   "name": "test2",
-  "strand": 0,
 }
 `;
 
 exports[`BED parser BED12 1`] = `
 Object {
-  "blockCount": "2",
-  "blockSizes": "567,488,",
-  "blockStarts": "0,3512",
+  "blockCount": 2,
+  "blockSizes": Array [
+    567,
+    488,
+  ],
+  "blockStart": Array [
+    0,
+    3512,
+  ],
   "chrom": "chr22",
   "chromEnd": 5000,
   "chromStart": 1000,
@@ -62,16 +65,22 @@ Object {
   "name": "cloneA",
   "score": 960,
   "strand": 1,
-  "thickEnd": "5000",
-  "thickStart": "1000",
+  "thickEnd": 5000,
+  "thickStart": 1000,
 }
 `;
 
 exports[`BED parser BED12 2`] = `
 Object {
-  "blockCount": "2",
-  "blockSizes": "433,399,",
-  "blockStarts": "0,3601",
+  "blockCount": 2,
+  "blockSizes": Array [
+    433,
+    399,
+  ],
+  "blockStart": Array [
+    0,
+    3601,
+  ],
   "chrom": "chr22",
   "chromEnd": 6000,
   "chromStart": 2000,
@@ -79,8 +88,8 @@ Object {
   "name": "cloneB",
   "score": 900,
   "strand": -1,
-  "thickEnd": "6000",
-  "thickStart": "2000",
+  "thickEnd": 6000,
+  "thickStart": 2000,
 }
 `;
 
@@ -209,7 +218,6 @@ Object {
   "sourceChrom": "chr17",
   "sourceEnd": 58880897,
   "sourceStart": 58878552,
-  "strand": 0,
   "targetChrom": "chr3",
   "targetEnd": 63705638,
   "targetStart": 63702628,
@@ -224,7 +232,6 @@ Object {
   "chromStart": 7917,
   "name": "2912",
   "qStart": 75185566,
-  "strand": 0,
 }
 `;
 
@@ -234,7 +241,6 @@ Object {
   "chromEnd": 2,
   "chromStart": 0,
   "mafBlock": "a score=60.000000;s hg38.chr22_KI270731v1_random        0 2 +   150754 AC;s canFam3.chr26                27974205 2 + 38964690 AT;",
-  "strand": 0,
 }
 `;
 
@@ -248,7 +254,19 @@ Object {
   "qValue": 4.80079,
   "score": 468,
   "signalValue": 103.84,
-  "strand": 0,
+}
+`;
+
+exports[`bigNarrowPeak with regularize bigNarrowPeak 1`] = `
+Object {
+  "end": 566953,
+  "pValue": 5.54347,
+  "peak": 154,
+  "qValue": 4.80079,
+  "refName": "chr1",
+  "score": 468,
+  "signalValue": 103.84,
+  "start": 566753,
 }
 `;
 
@@ -283,9 +301,7 @@ Object {
     463,
   ],
   "oSequence": "",
-  "oStrand": Array [
-    "+",
-  ],
+  "oStrand": "+",
   "repMatch": 0,
   "reserved": 0,
   "score": 1000,
@@ -327,9 +343,7 @@ Object {
     463,
   ],
   "oSequence": "cttgccgtcagccttttctttgacctcttctttctgttcatgtgtatctgctgtctcttagcccagacttcccgtgtcctttccaccgggcctttgggaggtcacagggtcttgatgctgtggtcttgatctgcaggtgtctgacttccagcaactgctggcctgtgccagggtggaagctgagcactggagtggagttttcctgtggagaggagccatgcctagagtgggatgggccattgttcatattctggcccctgttgtctgcatgtaacctaataccacgaccaggcatgggggaaagattggaggaaagttgagtgagaggatcaacttctctgacaacctaggccagtgtgtggtgatgccaggcatgcccttccccagcatcaggtctccagagctgcagaagacgacggccgacttggatcacactcttgtgagtgtccccagtgttgcagaggcagggccatcaggcaccaaagggattctgccagcatagtgctcctggaccagtgatacacccggcaccctgtcctggacaggctgttggcctggatctgagccctcgtggaggtcaaagccacctttggttctgccattactgctgtgtggaagttcactcctgccttttcctttcccgagagcctccaccaccccgagatcgcatttctcactgccttttgtctgcccagtttcaccagaagtaggcctcttcctgacaggcagctgcaccactgcctggcgctgcgcccttcctttgctctgcccgctggagacggtgtttgtcatgggcctggtctgcagggatcctgctacaaaggtgaaacccaggagagtgtggagtccagagtgttgccaggacccaggcacaggcattagtgcccgttggagaaaacaggggaatcccgaagaaatggtgggttttggccatccgtgagatcttcccagggcagctcccctctgtggaatccaatctgtcttccatcctgcgtggccgagggccaggcttctcactgggcctctgcaggaggctgccatttgtcctgcccaccgtcttagaagcgagacggagcagactcatctgctactgccctttctataataactaaagttagctgccctggactattcaccccctagtctcaatttaaaaagatccccatggccacagggcccctgcctgggggcttgtcacctcccccaccttcttcctgagtcacttctgcagccttgctccctaacctgccccacagccttgcctggatttctatctccctggcttggtgccagttcctccaagtcgatggcacctccctccctctcaaccacttgagcaaactccaagacatcttctaccccaacaccagcaattgtgccaagggccattaggctctcagcatgactatttttagagaccccgtgtctgtcactgaaaccttttttgtgggagactattcctcccatctgcaacagctgcccctgctgacggcccttctctcctccctctcatcccagagaaacaggtcagctgggagcttctgcccccactgcctagggaccaacaggggcaggaggcagtcactgaccccgagacgtttgca",
-  "oStrand": Array [
-    "+",
-  ],
+  "oStrand": "+",
   "repMatch": 0,
   "reserved": 0,
   "score": 1000,
@@ -361,11 +375,10 @@ Object {
   "chrom": "chr22_KI270731v1_random",
   "chromEnd": 9270,
   "chromStart": 0,
-  "leftStatus": Array [],
-  "rightStatus": Array [],
+  "leftStatus": "",
+  "rightStatus": "",
   "score": 0.568679,
   "src": "canFam3",
-  "strand": 0,
 }
 `;
 
@@ -403,7 +416,6 @@ Object {
     },
     Object {
       "comment": "+ or - for strand",
-      "isArray": true,
       "name": "strand",
       "size": 1,
       "type": "char",

--- a/test/__snapshots__/parse.test.js.snap
+++ b/test/__snapshots__/parse.test.js.snap
@@ -54,7 +54,7 @@ Object {
     567,
     488,
   ],
-  "blockStart": Array [
+  "blockStarts": Array [
     0,
     3512,
   ],
@@ -77,7 +77,7 @@ Object {
     433,
     399,
   ],
-  "blockStart": Array [
+  "blockStarts": Array [
     0,
     3601,
   ],

--- a/test/__snapshots__/parse.test.js.snap
+++ b/test/__snapshots__/parse.test.js.snap
@@ -2,50 +2,50 @@
 
 exports[`BED parser BED3 1`] = `
 Object {
-  "end": 10884,
-  "refName": "contigA",
-  "start": 10875,
+  "chrom": "contigA",
+  "chromEnd": 10884,
+  "chromStart": 10875,
   "strand": 0,
 }
 `;
 
 exports[`BED parser BED3 2`] = `
 Object {
-  "end": 10884,
-  "refName": "co,tigA",
-  "start": 10875,
+  "chrom": "co,tigA",
+  "chromEnd": 10884,
+  "chromStart": 10875,
   "strand": 0,
 }
 `;
 
 exports[`BED parser BED6 1`] = `
 Object {
-  "end": 10884,
+  "chrom": "contigA",
+  "chromEnd": 10884,
+  "chromStart": 10875,
   "name": "test",
-  "refName": "contigA",
   "score": 0.5,
-  "start": 10875,
   "strand": -1,
 }
 `;
 
 exports[`BED parser BED6 2`] = `
 Object {
-  "end": 10884,
+  "chrom": "co,tigA",
+  "chromEnd": 10884,
+  "chromStart": 10875,
   "name": "test2",
-  "refName": "co,tigA",
   "score": 0,
-  "start": 10875,
   "strand": 1,
 }
 `;
 
 exports[`BED parser BED6 3`] = `
 Object {
-  "end": 10884,
+  "chrom": "cotigA",
+  "chromEnd": 10884,
+  "chromStart": 10875,
   "name": "test2",
-  "refName": "cotigA",
-  "start": 10875,
   "strand": 0,
 }
 `;
@@ -55,12 +55,12 @@ Object {
   "blockCount": "2",
   "blockSizes": "567,488,",
   "blockStarts": "0,3512",
-  "end": 5000,
+  "chrom": "chr22",
+  "chromEnd": 5000,
+  "chromStart": 1000,
   "itemRgb": "0",
   "name": "cloneA",
-  "refName": "chr22",
   "score": 960,
-  "start": 1000,
   "strand": 1,
   "thickEnd": "5000",
   "thickStart": "1000",
@@ -72,12 +72,12 @@ Object {
   "blockCount": "2",
   "blockSizes": "433,399,",
   "blockStarts": "0,3601",
-  "end": 6000,
+  "chrom": "chr22",
+  "chromEnd": 6000,
+  "chromStart": 2000,
   "itemRgb": "0",
   "name": "cloneB",
-  "refName": "chr22",
   "score": 900,
-  "start": 2000,
   "strand": -1,
   "thickEnd": "6000",
   "thickStart": "2000",
@@ -86,62 +86,62 @@ Object {
 
 exports[`bigChain bigChain 1`] = `
 Object {
-  "chain_score": 66,
-  "end": 133710,
+  "chainScore": 66,
+  "chrom": "chr22_KI270731v1_random",
+  "chromEnd": 133710,
+  "chromStart": 133689,
   "name": "530549",
-  "q_end": 80144725,
-  "q_name": "chr16",
-  "q_size": 98207768,
-  "q_start": 80144720,
-  "refName": "chr22_KI270731v1_random",
+  "qEnd": 80144725,
+  "qName": "chr16",
+  "qSize": 98207768,
+  "qStart": 80144720,
   "score": 1000,
-  "start": 133689,
   "strand": -1,
-  "t_size": 150754,
+  "tSize": 150754,
 }
 `;
 
 exports[`bigGenePred bigGenePred 1`] = `
 Object {
-  "block_count": 3,
-  "block_sizes": Array [
+  "blockCount": 3,
+  "blockSizes": Array [
     359,
     109,
     1189,
   ],
-  "cds_end_stat": "none",
-  "cds_start_stat": "none",
-  "chrom_starts": Array [
+  "cdsEndStat": "none",
+  "cdsStartStat": "none",
+  "chrom": "chr1",
+  "chromEnd": 14409,
+  "chromStart": 11868,
+  "chromStarts": Array [
     0,
     744,
     1352,
   ],
-  "end": 14409,
-  "exon_frames": Array [
+  "exonFrames": Array [
     -1,
     -1,
     -1,
   ],
-  "gene_name": "ENST00000456328.2",
-  "gene_name2": "DDX11L1",
-  "gene_type": "none",
+  "geneName": "ENST00000456328.2",
+  "geneName2": "DDX11L1",
+  "geneType": "none",
   "name": "ENST00000456328.2",
   "name2": "DDX11L1",
-  "refName": "chr1",
   "reserved": "255,128,0",
   "score": 1000,
-  "start": 11868,
   "strand": 1,
-  "thick_end": 11868,
-  "thick_start": 11868,
+  "thickEnd": 11868,
+  "thickStart": 11868,
   "type": "none",
 }
 `;
 
 exports[`bigGenePred bigGenePred 2`] = `
 Object {
-  "block_count": 11,
-  "block_sizes": Array [
+  "blockCount": 11,
+  "blockSizes": Array [
     98,
     34,
     152,
@@ -154,9 +154,12 @@ Object {
     154,
     37,
   ],
-  "cds_end_stat": "none",
-  "cds_start_stat": "none",
-  "chrom_starts": Array [
+  "cdsEndStat": "none",
+  "cdsStartStat": "none",
+  "chrom": "chr1",
+  "chromEnd": 29570,
+  "chromStart": 14403,
+  "chromStarts": Array [
     0,
     601,
     1392,
@@ -169,8 +172,7 @@ Object {
     10334,
     15130,
   ],
-  "end": 29570,
-  "exon_frames": Array [
+  "exonFrames": Array [
     -1,
     -1,
     -1,
@@ -183,188 +185,186 @@ Object {
     -1,
     -1,
   ],
-  "gene_name": "ENST00000488147.1",
-  "gene_name2": "WASH7P",
-  "gene_type": "none",
+  "geneName": "ENST00000488147.1",
+  "geneName2": "WASH7P",
+  "geneType": "none",
   "name": "ENST00000488147.1",
   "name2": "WASH7P",
-  "refName": "chr1",
   "reserved": "255,128,0",
   "score": 1000,
-  "start": 14403,
   "strand": -1,
-  "thick_end": 14403,
-  "thick_start": 14403,
+  "thickEnd": 14403,
+  "thickStart": 14403,
   "type": "none",
 }
 `;
 
 exports[`bigInteract bigInteract 1`] = `
 Object {
+  "chrom": "chr3",
+  "chromEnd": 63705638,
+  "chromStart": 63702628,
   "color": "0",
-  "end": 63705638,
-  "refName": "chr3",
   "score": 584,
-  "source_chrom": "chr17",
-  "source_end": 58880897,
-  "source_start": 58878552,
-  "start": 63702628,
+  "sourceChrom": "chr17",
+  "sourceEnd": 58880897,
+  "sourceStart": 58878552,
   "strand": 0,
-  "target_chrom": "chr3",
-  "target_end": 63705638,
-  "target_start": 63702628,
+  "targetChrom": "chr3",
+  "targetEnd": 63705638,
+  "targetStart": 63702628,
   "value": "10",
 }
 `;
 
 exports[`bigLink bigLink 1`] = `
 Object {
-  "end": 7918,
+  "chrom": "chr22_KI270731v1_random",
+  "chromEnd": 7918,
+  "chromStart": 7917,
   "name": "2912",
-  "q_start": 75185566,
-  "refName": "chr22_KI270731v1_random",
-  "start": 7917,
+  "qStart": 75185566,
   "strand": 0,
 }
 `;
 
 exports[`bigMaf bigMaf 1`] = `
 Object {
-  "end": 2,
-  "maf_block": "a score=60.000000;s hg38.chr22_KI270731v1_random        0 2 +   150754 AC;s canFam3.chr26                27974205 2 + 38964690 AT;",
-  "refName": "chr22_KI270731v1_random",
-  "start": 0,
+  "chrom": "chr22_KI270731v1_random",
+  "chromEnd": 2,
+  "chromStart": 0,
+  "mafBlock": "a score=60.000000;s hg38.chr22_KI270731v1_random        0 2 +   150754 AC;s canFam3.chr26                27974205 2 + 38964690 AT;",
   "strand": 0,
 }
 `;
 
 exports[`bigNarrowPeak bigNarrowPeak 1`] = `
 Object {
-  "end": 566953,
-  "p_value": 5.54347,
+  "chrom": "chr1",
+  "chromEnd": 566953,
+  "chromStart": 566753,
+  "pValue": 5.54347,
   "peak": 154,
-  "q_value": 4.80079,
-  "refName": "chr1",
+  "qValue": 4.80079,
   "score": 468,
-  "signal_value": 103.84,
-  "start": 566753,
+  "signalValue": 103.84,
   "strand": 0,
 }
 `;
 
 exports[`bigPsl bigPsl 1`] = `
 Object {
-  "block_count": 3,
-  "block_sizes": Array [
+  "blockCount": 3,
+  "blockSizes": Array [
     354,
     109,
     1141,
   ],
-  "chrom_size": 248956422,
-  "chrom_starts": Array [
+  "chrom": "chr1",
+  "chromEnd": 14361,
+  "chromSize": 248956422,
+  "chromStart": 11873,
+  "chromStarts": Array [
     0,
     739,
     1347,
   ],
-  "end": 14361,
   "match": 1579,
-  "mis_match": 25,
-  "n_count": 0,
+  "misMatch": 25,
+  "nCount": 0,
   "name": "mAM992877",
-  "o_cds": "",
-  "o_chrom_end": 1604,
-  "o_chrom_size": 1604,
-  "o_chrom_start": 0,
-  "o_chrom_starts": Array [
+  "oCDS": "",
+  "oChromEnd": 1604,
+  "oChromSize": 1604,
+  "oChromStart": 0,
+  "oChromStarts": Array [
     0,
     354,
     463,
   ],
-  "o_sequence": "",
-  "o_strand": Array [
+  "oSequence": "",
+  "oStrand": Array [
     "+",
   ],
-  "refName": "chr1",
-  "rep_match": 0,
+  "repMatch": 0,
   "reserved": 0,
   "score": 1000,
-  "seq_type": 0,
-  "start": 11873,
+  "seqType": 0,
   "strand": 1,
-  "thick_end": 14361,
-  "thick_start": 11873,
+  "thickEnd": 14361,
+  "thickStart": 11873,
 }
 `;
 
 exports[`bigPsl bigPsl 2`] = `
 Object {
-  "block_count": 3,
-  "block_sizes": Array [
+  "blockCount": 3,
+  "blockSizes": Array [
     354,
     109,
     1141,
   ],
-  "chrom_size": 248956422,
-  "chrom_starts": Array [
+  "chrom": "chr1",
+  "chromEnd": 14361,
+  "chromSize": 248956422,
+  "chromStart": 11873,
+  "chromStarts": Array [
     0,
     739,
     1347,
   ],
-  "end": 14361,
   "match": 1579,
-  "mis_match": 25,
-  "n_count": 0,
+  "misMatch": 25,
+  "nCount": 0,
   "name": "mAM992877",
-  "o_cds": "365..502",
-  "o_chrom_end": 1604,
-  "o_chrom_size": 1604,
-  "o_chrom_start": 0,
-  "o_chrom_starts": Array [
+  "oCDS": "365..502",
+  "oChromEnd": 1604,
+  "oChromSize": 1604,
+  "oChromStart": 0,
+  "oChromStarts": Array [
     0,
     354,
     463,
   ],
-  "o_sequence": "cttgccgtcagccttttctttgacctcttctttctgttcatgtgtatctgctgtctcttagcccagacttcccgtgtcctttccaccgggcctttgggaggtcacagggtcttgatgctgtggtcttgatctgcaggtgtctgacttccagcaactgctggcctgtgccagggtggaagctgagcactggagtggagttttcctgtggagaggagccatgcctagagtgggatgggccattgttcatattctggcccctgttgtctgcatgtaacctaataccacgaccaggcatgggggaaagattggaggaaagttgagtgagaggatcaacttctctgacaacctaggccagtgtgtggtgatgccaggcatgcccttccccagcatcaggtctccagagctgcagaagacgacggccgacttggatcacactcttgtgagtgtccccagtgttgcagaggcagggccatcaggcaccaaagggattctgccagcatagtgctcctggaccagtgatacacccggcaccctgtcctggacaggctgttggcctggatctgagccctcgtggaggtcaaagccacctttggttctgccattactgctgtgtggaagttcactcctgccttttcctttcccgagagcctccaccaccccgagatcgcatttctcactgccttttgtctgcccagtttcaccagaagtaggcctcttcctgacaggcagctgcaccactgcctggcgctgcgcccttcctttgctctgcccgctggagacggtgtttgtcatgggcctggtctgcagggatcctgctacaaaggtgaaacccaggagagtgtggagtccagagtgttgccaggacccaggcacaggcattagtgcccgttggagaaaacaggggaatcccgaagaaatggtgggttttggccatccgtgagatcttcccagggcagctcccctctgtggaatccaatctgtcttccatcctgcgtggccgagggccaggcttctcactgggcctctgcaggaggctgccatttgtcctgcccaccgtcttagaagcgagacggagcagactcatctgctactgccctttctataataactaaagttagctgccctggactattcaccccctagtctcaatttaaaaagatccccatggccacagggcccctgcctgggggcttgtcacctcccccaccttcttcctgagtcacttctgcagccttgctccctaacctgccccacagccttgcctggatttctatctccctggcttggtgccagttcctccaagtcgatggcacctccctccctctcaaccacttgagcaaactccaagacatcttctaccccaacaccagcaattgtgccaagggccattaggctctcagcatgactatttttagagaccccgtgtctgtcactgaaaccttttttgtgggagactattcctcccatctgcaacagctgcccctgctgacggcccttctctcctccctctcatcccagagaaacaggtcagctgggagcttctgcccccactgcctagggaccaacaggggcaggaggcagtcactgaccccgagacgtttgca",
-  "o_strand": Array [
+  "oSequence": "cttgccgtcagccttttctttgacctcttctttctgttcatgtgtatctgctgtctcttagcccagacttcccgtgtcctttccaccgggcctttgggaggtcacagggtcttgatgctgtggtcttgatctgcaggtgtctgacttccagcaactgctggcctgtgccagggtggaagctgagcactggagtggagttttcctgtggagaggagccatgcctagagtgggatgggccattgttcatattctggcccctgttgtctgcatgtaacctaataccacgaccaggcatgggggaaagattggaggaaagttgagtgagaggatcaacttctctgacaacctaggccagtgtgtggtgatgccaggcatgcccttccccagcatcaggtctccagagctgcagaagacgacggccgacttggatcacactcttgtgagtgtccccagtgttgcagaggcagggccatcaggcaccaaagggattctgccagcatagtgctcctggaccagtgatacacccggcaccctgtcctggacaggctgttggcctggatctgagccctcgtggaggtcaaagccacctttggttctgccattactgctgtgtggaagttcactcctgccttttcctttcccgagagcctccaccaccccgagatcgcatttctcactgccttttgtctgcccagtttcaccagaagtaggcctcttcctgacaggcagctgcaccactgcctggcgctgcgcccttcctttgctctgcccgctggagacggtgtttgtcatgggcctggtctgcagggatcctgctacaaaggtgaaacccaggagagtgtggagtccagagtgttgccaggacccaggcacaggcattagtgcccgttggagaaaacaggggaatcccgaagaaatggtgggttttggccatccgtgagatcttcccagggcagctcccctctgtggaatccaatctgtcttccatcctgcgtggccgagggccaggcttctcactgggcctctgcaggaggctgccatttgtcctgcccaccgtcttagaagcgagacggagcagactcatctgctactgccctttctataataactaaagttagctgccctggactattcaccccctagtctcaatttaaaaagatccccatggccacagggcccctgcctgggggcttgtcacctcccccaccttcttcctgagtcacttctgcagccttgctccctaacctgccccacagccttgcctggatttctatctccctggcttggtgccagttcctccaagtcgatggcacctccctccctctcaaccacttgagcaaactccaagacatcttctaccccaacaccagcaattgtgccaagggccattaggctctcagcatgactatttttagagaccccgtgtctgtcactgaaaccttttttgtgggagactattcctcccatctgcaacagctgcccctgctgacggcccttctctcctccctctcatcccagagaaacaggtcagctgggagcttctgcccccactgcctagggaccaacaggggcaggaggcagtcactgaccccgagacgtttgca",
+  "oStrand": Array [
     "+",
   ],
-  "refName": "chr1",
-  "rep_match": 0,
+  "repMatch": 0,
   "reserved": 0,
   "score": 1000,
-  "seq_type": 1,
-  "start": 11873,
+  "seqType": 1,
   "strand": 1,
-  "thick_end": 13259,
-  "thick_start": 12622,
+  "thickEnd": 13259,
+  "thickStart": 12622,
 }
 `;
 
 exports[`mafFrames mafFrames 1`] = `
 Object {
-  "end": 12574,
+  "chrom": "chr22_KI270731v1_random",
+  "chromEnd": 12574,
+  "chromStart": 11287,
   "frame": "0",
-  "is_exon_end": "1",
-  "is_exon_start": "1",
+  "isExonEnd": "1",
+  "isExonStart": "1",
   "name": "ENST00000619792.1",
-  "next_frame_pos": -1,
-  "prev_frame_pos": -1,
-  "refName": "chr22_KI270731v1_random",
+  "nextFramePos": -1,
+  "prevFramePos": -1,
   "src": "hg38",
-  "start": 11287,
   "strand": -1,
 }
 `;
 
 exports[`mafSummary mafSummary 1`] = `
 Object {
-  "end": 9270,
-  "left_status": Array [],
-  "refName": "chr22_KI270731v1_random",
-  "right_status": Array [],
+  "chrom": "chr22_KI270731v1_random",
+  "chromEnd": 9270,
+  "chromStart": 0,
+  "leftStatus": Array [],
+  "rightStatus": Array [],
   "score": 0.568679,
   "src": "canFam3",
-  "start": 0,
   "strand": 0,
 }
 `;
@@ -380,11 +380,13 @@ Object {
     },
     Object {
       "comment": "Start position of feature on chromosome",
+      "isNumeric": true,
       "name": "chromStart",
       "type": "uint",
     },
     Object {
       "comment": "End position of feature on chromosome",
+      "isNumeric": true,
       "name": "chromEnd",
       "type": "uint",
     },
@@ -395,27 +397,32 @@ Object {
     },
     Object {
       "comment": "Score",
+      "isNumeric": true,
       "name": "score",
       "type": "uint",
     },
     Object {
       "comment": "+ or - for strand",
+      "isArray": true,
       "name": "strand",
       "size": 1,
       "type": "char",
     },
     Object {
       "comment": "Coding region start",
+      "isNumeric": true,
       "name": "thickStart",
       "type": "uint",
     },
     Object {
       "comment": "Coding region end",
+      "isNumeric": true,
       "name": "thickEnd",
       "type": "uint",
     },
     Object {
       "comment": "Green on + strand, Red on - strand",
+      "isNumeric": true,
       "name": "reserved",
       "type": "uint",
     },

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -199,18 +199,3 @@ test('real world', () => {
   const p = new BED({ autoSql })
   expect(p.autoSql).toMatchSnapshot()
 })
-
-test('generate README output', () => {
-  const p = new BED()
-  const f1 = p.parseLine('chr1\t0\t100')
-  // outputs { chrom: 'chr1', chromStart: 0, chromEnd: 100 }
-  const f2 = p.parseLine('chr1\t0\t100', { regularize: true, uniqueId: 1 })
-  // outputs { uniqueId: 1, refName: 'chr1', start: 0, end: 100 }
-  console.log(f1)
-  console.log(f2)
-  // console.log(p.parseLine('chr1\t0\t100'))
-  // const p2 = new BED({ type: 'bigGenePred' })
-  // const line =
-  //   'chr1\t11868\t14409\tENST00000456328.2\t1000\t+\t11868\t11868\t255,128,0\t3\t359,109,1189,\t0,744,1352,\tDDX11L1\tnone\tnone\t-1,-1,-1,\tnone\tENST00000456328.2\tDDX11L1\tnone'
-  // console.log(p2.parseLine(line))
-})

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -9,10 +9,17 @@ describe('BED parser', () => {
   it('BED3', () => {
     const f1 = p.parseLine('contigA\t10875\t10884')
     const f2 = p.parseLine('co%2CtigA\t10875\t10884')
+    const f3 = p.parseLine(['contigA', '10875', '10884'])
     expect(f1).toMatchSnapshot()
     expect(f2).toMatchSnapshot()
+    expect(f3).toEqual(f1)
   })
 
+  it('errors', () => {
+    expect(() => new BED({ type: 'notexist' })).toThrow(/not found/)
+    expect(() => p.parseLine('track hello test')).toThrow(/not supported/)
+    expect(() => p.parseLine('browser hello test')).toThrow(/not supported/)
+  })
   it('BED6', () => {
     const f1 = p.parseLine('contigA\t10875\t10884\ttest\t0.50\t-')
     const f2 = p.parseLine('co%2CtigA\t10875\t10884\ttest2\t0\t+')
@@ -23,6 +30,7 @@ describe('BED parser', () => {
     expect(f2.chrom).toEqual('co,tigA')
     expect(f2.chromStart).toEqual(10875)
     expect(f2.chromEnd).toEqual(10884)
+    expect(f3.strand).toEqual(0)
   })
   it('BED12', () => {
     const f1 = p.parseLine(
@@ -153,33 +161,22 @@ describe('bigLink', () => {
   })
 })
 
-describe('bigNarrowPeak', () => {
-  let p
-  beforeAll(() => {
-    p = new BED({ type: 'bigNarrowPeak' })
-  })
+test('bigNarrowPeak', () => {
+  const p = new BED({ type: 'bigNarrowPeak' })
 
-  it('bigNarrowPeak', () => {
-    const f1 = p.parseLine(
+  expect(
+    p.parseLine(
       'chr1\t566753\t566953\t.\t468\t.\t103.84\t5.54347\t4.80079\t154',
-    )
-    expect(f1).toMatchSnapshot()
-  })
+    ),
+  ).toMatchSnapshot()
+  expect(
+    p.parseLine(
+      'chr1\t566753\t566953\t.\t468\t.\t103.84\t5.54347\t4.80079\t154',
+      { uniqueId: 1 },
+    ),
+  ).toMatchSnapshot()
 })
-describe('bigNarrowPeak with regularize', () => {
-  let p
-  beforeAll(() => {
-    p = new BED({ type: 'bigNarrowPeak' })
-  })
 
-  it('bigNarrowPeak', () => {
-    const f1 = p.parseLine(
-      'chr1\t566753\t566953\t.\t468\t.\t103.84\t5.54347\t4.80079\t154',
-      { regularize: true },
-    )
-    expect(f1).toMatchSnapshot()
-  })
-})
 test('real world', () => {
   const autoSql = `table hg18KGchr7
     "UCSC Genes for chr7 with color plus GeneSymbol and SwissProtID"

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -166,7 +166,20 @@ describe('bigNarrowPeak', () => {
     expect(f1).toMatchSnapshot()
   })
 })
+describe('bigNarrowPeak with regularize', () => {
+  let p
+  beforeAll(() => {
+    p = new BED({ type: 'bigNarrowPeak' })
+  })
 
+  it('bigNarrowPeak', () => {
+    const f1 = p.parseLine(
+      'chr1\t566753\t566953\t.\t468\t.\t103.84\t5.54347\t4.80079\t154',
+      { regularize: true },
+    )
+    expect(f1).toMatchSnapshot()
+  })
+})
 test('real world', () => {
   const autoSql = `table hg18KGchr7
     "UCSC Genes for chr7 with color plus GeneSymbol and SwissProtID"
@@ -189,9 +202,15 @@ test('real world', () => {
 
 test('generate README output', () => {
   const p = new BED()
-  console.log(p.parseLine('chr1\t0\t100'))
-  const p2 = new BED({ type: 'bigGenePred' })
-  const line =
-    'chr1\t11868\t14409\tENST00000456328.2\t1000\t+\t11868\t11868\t255,128,0\t3\t359,109,1189,\t0,744,1352,\tDDX11L1\tnone\tnone\t-1,-1,-1,\tnone\tENST00000456328.2\tDDX11L1\tnone'
-  console.log(p2.parseLine(line))
+  const f1 = p.parseLine('chr1\t0\t100')
+  // outputs { chrom: 'chr1', chromStart: 0, chromEnd: 100 }
+  const f2 = p.parseLine('chr1\t0\t100', { regularize: true, uniqueId: 1 })
+  // outputs { uniqueId: 1, refName: 'chr1', start: 0, end: 100 }
+  console.log(f1)
+  console.log(f2)
+  // console.log(p.parseLine('chr1\t0\t100'))
+  // const p2 = new BED({ type: 'bigGenePred' })
+  // const line =
+  //   'chr1\t11868\t14409\tENST00000456328.2\t1000\t+\t11868\t11868\t255,128,0\t3\t359,109,1189,\t0,744,1352,\tDDX11L1\tnone\tnone\t-1,-1,-1,\tnone\tENST00000456328.2\tDDX11L1\tnone'
+  // console.log(p2.parseLine(line))
 })

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -20,9 +20,9 @@ describe('BED parser', () => {
     expect(f1).toMatchSnapshot()
     expect(f2).toMatchSnapshot()
     expect(f3).toMatchSnapshot()
-    expect(f2.refName).toEqual('co,tigA')
-    expect(f2.start).toEqual(10875)
-    expect(f2.end).toEqual(10884)
+    expect(f2.chrom).toEqual('co,tigA')
+    expect(f2.chromStart).toEqual(10875)
+    expect(f2.chromEnd).toEqual(10884)
   })
   it('BED12', () => {
     const f1 = p.parseLine(
@@ -167,7 +167,7 @@ describe('bigNarrowPeak', () => {
   })
 })
 
-xtest('real world', () => {
+test('real world', () => {
   const autoSql = `table hg18KGchr7
     "UCSC Genes for chr7 with color plus GeneSymbol and SwissProtID"
     (
@@ -185,4 +185,13 @@ xtest('real world', () => {
     )`
   const p = new BED({ autoSql })
   expect(p.autoSql).toMatchSnapshot()
+})
+
+test('generate README output', () => {
+  const p = new BED()
+  console.log(p.parseLine('chr1\t0\t100'))
+  const p2 = new BED({ type: 'bigGenePred' })
+  const line =
+    'chr1\t11868\t14409\tENST00000456328.2\t1000\t+\t11868\t11868\t255,128,0\t3\t359,109,1189,\t0,744,1352,\tDDX11L1\tnone\tnone\t-1,-1,-1,\tnone\tENST00000456328.2\tDDX11L1\tnone'
+  console.log(p2.parseLine(line))
 })


### PR DESCRIPTION
I am proposing some API changes to this module. The previous iteration of this had some fairly cobbled together functions where eventually things like @gmod/bbi were calling sort of internal methods of the module with a weird thing called "offset" that skipped several fields of the autoSql schema.

After this API change, all usage of this module should use the parseLine method which accepts a text line or an array of fields. It also accepts an opts object that can contain a opts.uniqueId that will be incorporated onto the object, and possibly other things that may help the API remain stable/extensible if something else needs to be added.


